### PR TITLE
Fix

### DIFF
--- a/simp_cuda/src/cusimp_free.cu
+++ b/simp_cuda/src/cusimp_free.cu
@@ -81,6 +81,8 @@ namespace cusimp_free
             CHECK_CUDA(cudaFree(vertices_invalid_table));
             CHECK_CUDA(
                 cudaMalloc((void **)&vertices_invalid_table, (allocated_pts + 1) * sizeof(bool)));
+            // cudaMalloc is not zero-fill; dirty bits block edge collapses.
+            CHECK_CUDA(cudaMemset(vertices_invalid_table, 0, (allocated_pts + 1) * sizeof(bool)));
         }
     }
 
@@ -898,24 +900,13 @@ namespace cusimp_free
         n_vertices_undo = 0;
         n_invalid_vertices = 0;
         int first_n_vertices_undo = 0;
-        // if is stuck, accumulate the invalid list
+        // if is stuck, accumulate the invalid list (needs buffers from a prior
+        // forward; first call always starts with is_stuck=false).
         if(is_stuck){
             cudaMemcpy(tmp_vertices_undo_list, verts_undo, n_verts_undo * sizeof(int), cudaMemcpyDeviceToDevice);
             n_vertices_undo += n_verts_undo;
             rearrange_index_of_undo_vertices<<<(n_vertices_undo + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, first_n_vertices_undo);
             first_n_vertices_undo += n_verts_undo;
-        }
-        else{
-            if(n_verts_undo != 0)
-                CHECK_CUDA(cudaMemset(vertices_invalid_table, 0, (allocated_pts + 1) * sizeof(bool)));
-        }
-
-        if (n_verts_undo != 0)
-        {
-            // not stuck, set vertics_invalid_table as all 0
-            cudaMemcpy(vertices_invalid_list, verts_undo, n_verts_undo * sizeof(int), cudaMemcpyDeviceToDevice);
-            n_invalid_vertices = n_verts_undo;
-            compute_invalid_vertices_table<<<(n_invalid_vertices + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
         }
 
         int first_n_edges_undo_init_val = first_n_vertices_undo;
@@ -929,14 +920,29 @@ namespace cusimp_free
         resize(nPts, nTris);
 
         ensure_pts_storage_size(n_pts);
+        // pts/tris are torch CUDA tensors — must be D2D (H2D reads device ptrs as host).
         CHECK_CUDA(cudaMemcpy(points, pts, n_pts * sizeof(Vertex<float>),
-                              cudaMemcpyHostToDevice));
+                              cudaMemcpyDeviceToDevice));
         std::vector<int> tmp(n_pts, 1);
         CHECK_CUDA(cudaMemcpy(pts_occ, tmp.data(), n_pts * sizeof(int), cudaMemcpyHostToDevice));
         CHECK_CUDA(cudaMemset(pts_occ + n_pts, 0, sizeof(int)));
         ensure_tris_storage_size(n_tris);
         CHECK_CUDA(cudaMemcpy(triangles, tris, n_tris * sizeof(Triangle<int>),
-                              cudaMemcpyHostToDevice));
+                              cudaMemcpyDeviceToDevice));
+
+        // Invalid-mask init must run *after* ensure_pts (table may be newly malloc'd).
+        // When not stuck, clear every forward so recycled dirty memory cannot mark
+        // random verts invalid and stall collapse (multi-run no-op / ~remesh face count).
+        // When stuck, keep accumulated bits and only OR in the new undo verts below.
+        if (!is_stuck) {
+            CHECK_CUDA(cudaMemset(vertices_invalid_table, 0, (allocated_pts + 1) * sizeof(bool)));
+        }
+        if (n_verts_undo != 0) {
+            cudaMemcpy(vertices_invalid_list, verts_undo, n_verts_undo * sizeof(int), cudaMemcpyDeviceToDevice);
+            n_invalid_vertices = n_verts_undo;
+            compute_invalid_vertices_table<<<(n_invalid_vertices + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+        }
+
         if (init){
             thrust::device_ptr<Triangle<int>> thrust_triangles(triangles);
             thrust::default_random_engine rng;
@@ -998,6 +1004,10 @@ namespace cusimp_free
         // Avoid zero-block kernel launches and zero-sized edge buffers.
         if (n_edges > 0) {
             ensure_edge_cost_storage_size(n_edges);
+            // Cost kernel leaves many edges unwritten (early return on topology /
+            // is_stuck). Default to max so dirty recycled buffers cannot look like
+            // free collapses — or, after free/realloc, like all-blocked costs.
+            CHECK_CUDA(cudaMemset(edge_cost, 0xFF, n_edges * sizeof(uint32_t)));
             compute_edge_cost_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, is_stuck);
             CHECK_CUDA(cudaMemcpy(original_edge_cost, edge_cost, n_edges * sizeof(uint32_t), cudaMemcpyDeviceToDevice));
 

--- a/simp_cuda/src/cusimp_free.cu
+++ b/simp_cuda/src/cusimp_free.cu
@@ -98,6 +98,9 @@ namespace cusimp_free
             CHECK_CUDA(
                 cudaMalloc((void **)&original_tris, (allocated_tris + 1) * sizeof(Triangle<int>)));
 
+            // free before capacity growth; previous allocation would leak
+            CHECK_CUDA(cudaFree(intersected_triangle_idx));
+            intersected_triangle_idx = nullptr;
             CHECK_CUDA(cudaMalloc((void **)&intersected_triangle_idx, 2 * (allocated_tris + 1) * sizeof(unsigned int)));
             
             // memory for bvh construction and self intersection check
@@ -981,69 +984,96 @@ namespace cusimp_free
         ensure_vert_Q_storage_size(n_pts);
         compute_vert_Q_kernel<<<(n_pts + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
 
-        ensure_edge_cost_storage_size(n_edges);
-        compute_edge_cost_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, is_stuck);
-        CHECK_CUDA(cudaMemcpy(original_edge_cost, edge_cost, n_edges * sizeof(uint32_t), cudaMemcpyDeviceToDevice));
-
-        // cost propagate
-        ensure_tri_min_cost_storage_size(n_tris);
-        std::vector<uint64_cu> temp(n_tris, std::numeric_limits<uint64_cu>::max());
-        CHECK_CUDA(cudaMemcpy(tri_min_cost, temp.data(), n_tris * sizeof(uint64_cu), cudaMemcpyHostToDevice));
-        propagate_edge_cost_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
-
-        // collapsed edge
+        // free before re-malloc: previous forward() left these allocated (only
+        // n_intersect was freed), leaking collapsed_edge_idx (~O(n_edges) per
+        // call) across multi-iteration runs
+        CHECK_CUDA(cudaFree(n_collapsed));
+        n_collapsed = nullptr;
         CHECK_CUDA(cudaMalloc((void **)&n_collapsed, sizeof(int)));
         CHECK_CUDA(cudaMemset(n_collapsed, 0, sizeof(int)));
-        CHECK_CUDA(cudaMalloc((void **)&collapsed_edge_idx, n_edges * sizeof(int)));
-        CHECK_CUDA(cudaMemset(collapsed_edge_idx, 0, n_edges * sizeof(int)));
-        collapse_edge_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+        CHECK_CUDA(cudaFree(collapsed_edge_idx));
+        collapsed_edge_idx = nullptr;
+
+        // Full edge-dependent section: cost, propagate, collapse, cleanup.
+        // Avoid zero-block kernel launches and zero-sized edge buffers.
+        if (n_edges > 0) {
+            ensure_edge_cost_storage_size(n_edges);
+            compute_edge_cost_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, is_stuck);
+            CHECK_CUDA(cudaMemcpy(original_edge_cost, edge_cost, n_edges * sizeof(uint32_t), cudaMemcpyDeviceToDevice));
+
+            // cost propagate
+            ensure_tri_min_cost_storage_size(n_tris);
+            std::vector<uint64_cu> temp(n_tris, std::numeric_limits<uint64_cu>::max());
+            CHECK_CUDA(cudaMemcpy(tri_min_cost, temp.data(), n_tris * sizeof(uint64_cu), cudaMemcpyHostToDevice));
+            propagate_edge_cost_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+
+            CHECK_CUDA(cudaMalloc((void **)&collapsed_edge_idx, n_edges * sizeof(int)));
+            CHECK_CUDA(cudaMemset(collapsed_edge_idx, 0, n_edges * sizeof(int)));
+            collapse_edge_kernel<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+        }
 
         // check num_collapsed-----------
-        cudaMalloc((void **)&n_intersect, sizeof(unsigned int));
+        CHECK_CUDA(cudaFree(n_intersect));
+        n_intersect = nullptr;
+        CHECK_CUDA(cudaMalloc((void **)&n_intersect, sizeof(unsigned int)));
 
         int h_n_collapsed = 0;
+        CHECK_CUDA(cudaFree(n_edges_undo));
+        n_edges_undo = nullptr;
         CHECK_CUDA(cudaMalloc(&n_edges_undo, sizeof(int)));
         CHECK_CUDA(cudaMemset(n_edges_undo, 0, sizeof(int)));
         CHECK_CUDA(cudaMemcpy(&h_n_collapsed, n_collapsed, sizeof(int), cudaMemcpyDeviceToHost));
-        CHECK_CUDA(cudaMalloc(&edges_undo, 2 * h_n_collapsed * sizeof(int)));
-        CHECK_CUDA(cudaMemset(edges_undo, 0, 2 * h_n_collapsed * sizeof(int)));
+        CHECK_CUDA(cudaFree(edges_undo));
+        edges_undo = nullptr;
+        // Guard zero-sized allocation when no edges collapsed
+        if (h_n_collapsed > 0) {
+            CHECK_CUDA(cudaMalloc(&edges_undo, 2 * (size_t)h_n_collapsed * sizeof(int)));
+            CHECK_CUDA(cudaMemset(edges_undo, 0, 2 * (size_t)h_n_collapsed * sizeof(int)));
+        }
 
         remove_invalid_faces<<<(n_tris + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
-        remove_line_edge_collapse<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
-        // self intersection check after collapse
-        bool isIntersect = selfx::self_intersect(this, n_pts, n_tris, epsilon);
-        CHECK_CUDA(cudaMemset(n_edges_undo, 0, sizeof(int)));
-        get_undo_candidate_kernel<<<(h_n_collapsed + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
-        cudaDeviceSynchronize();
-
-        // get number of edges undo
-        int h_n_edges_undo = 0;
-        cudaMemcpy(&h_n_edges_undo, n_edges_undo, sizeof(int), cudaMemcpyDeviceToHost);
-        n_vertices_undo += 2 * h_n_edges_undo;
-        int i = 0;
-        while(h_n_edges_undo != 0){
-            i++;
-            undo_collapse_kernel<<<(h_n_collapsed + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
-            rearrange_index_of_undo_vertices<<<(n_vertices_undo + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, first_n_vertices_undo);
-            cudaDeviceSynchronize();
-            first_n_vertices_undo += 2 * h_n_edges_undo;
-
-            bool afterUndo = selfx::self_intersect(this, n_pts, n_tris, epsilon);
-            cudaDeviceSynchronize();
+        if (n_edges > 0) {
+            remove_line_edge_collapse<<<(n_edges + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+        }
+        // self-intersection / undo only when edges actually collapsed (avoids
+        // launching get_undo_candidate_kernel with a zero-sized grid)
+        if (h_n_collapsed > 0) {
+            bool isIntersect = selfx::self_intersect(this, n_pts, n_tris, epsilon);
             CHECK_CUDA(cudaMemset(n_edges_undo, 0, sizeof(int)));
             get_undo_candidate_kernel<<<(h_n_collapsed + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
             cudaDeviceSynchronize();
+
+            // get number of edges undo
+            int h_n_edges_undo = 0;
             cudaMemcpy(&h_n_edges_undo, n_edges_undo, sizeof(int), cudaMemcpyDeviceToHost);
             n_vertices_undo += 2 * h_n_edges_undo;
+            int i = 0;
+            while(h_n_edges_undo != 0){
+                i++;
+                undo_collapse_kernel<<<(h_n_collapsed + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+                rearrange_index_of_undo_vertices<<<(n_vertices_undo + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this, first_n_vertices_undo);
+                cudaDeviceSynchronize();
+                first_n_vertices_undo += 2 * h_n_edges_undo;
 
-            if(i == 5) break;
+                bool afterUndo = selfx::self_intersect(this, n_pts, n_tris, epsilon);
+                cudaDeviceSynchronize();
+                CHECK_CUDA(cudaMemset(n_edges_undo, 0, sizeof(int)));
+                get_undo_candidate_kernel<<<(h_n_collapsed + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(*this);
+                cudaDeviceSynchronize();
+                cudaMemcpy(&h_n_edges_undo, n_edges_undo, sizeof(int), cudaMemcpyDeviceToHost);
+                n_vertices_undo += 2 * h_n_edges_undo;
+
+                if(i == 5) break;
+            }
         }
 
+        // final vertex compaction (runs even when nothing collapsed)
         CHECK_CUDA(cudaMemcpy(pts_map, pts_occ, (n_pts + 1) * sizeof(int), cudaMemcpyDeviceToDevice));
         cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes, pts_map, pts_map, n_pts + 1);
         ensure_temp_storage_size(temp_storage_bytes);
         cub::DeviceScan::ExclusiveSum(temp_storage, allocated_temp_storage_size, pts_map, pts_map, n_pts + 1);
 
         CHECK_CUDA(cudaFree(n_intersect));
+        n_intersect = nullptr;
     }
 }

--- a/simp_cuda/src/pybind.cpp
+++ b/simp_cuda/src/pybind.cpp
@@ -17,35 +17,44 @@ namespace cusimp_free
   {
     CUSimp_Free pamo;
 
+    void release()
+    {
+      cudaDeviceSynchronize();
+      // cudaFree(nullptr) is a no-op; free every owned buffer once and null
+      // so a double-free path cannot use a stale pointer.
+      cudaFree(pamo.temp_storage); pamo.temp_storage = nullptr;
+      cudaFree(pamo.first_near_tris); pamo.first_near_tris = nullptr;
+      cudaFree(pamo.near_tris); pamo.near_tris = nullptr;
+      cudaFree(pamo.near_offset); pamo.near_offset = nullptr;
+      cudaFree(pamo.first_edge); pamo.first_edge = nullptr;
+      cudaFree(pamo.edges); pamo.edges = nullptr;
+      cudaFree(pamo.vert_Q); pamo.vert_Q = nullptr;
+      cudaFree(pamo.edge_cost); pamo.edge_cost = nullptr;
+      cudaFree(pamo.tri_min_cost); pamo.tri_min_cost = nullptr;
+      cudaFree(pamo.points); pamo.points = nullptr;
+      cudaFree(pamo.pts_occ); pamo.pts_occ = nullptr;
+      cudaFree(pamo.pts_map); pamo.pts_map = nullptr;
+      cudaFree(pamo.triangles); pamo.triangles = nullptr;
+      cudaFree(pamo.n_collapsed); pamo.n_collapsed = nullptr;
+      cudaFree(pamo.original_points); pamo.original_points = nullptr;
+      cudaFree(pamo.original_tris); pamo.original_tris = nullptr;
+      cudaFree(pamo.original_edge_cost); pamo.original_edge_cost = nullptr;
+      cudaFree(pamo.collapsed_edge_idx); pamo.collapsed_edge_idx = nullptr;
+      cudaFree(pamo.n_edges_undo); pamo.n_edges_undo = nullptr;
+      cudaFree(pamo.edges_undo); pamo.edges_undo = nullptr;
+      cudaFree(pamo.vertices_undo_list); pamo.vertices_undo_list = nullptr;
+      cudaFree(pamo.tmp_vertices_undo_list); pamo.tmp_vertices_undo_list = nullptr;
+      cudaFree(pamo.vertices_invalid_list); pamo.vertices_invalid_list = nullptr;
+      cudaFree(pamo.vertices_invalid_table); pamo.vertices_invalid_table = nullptr;
+      cudaFree(pamo.query_triangle_list); pamo.query_triangle_list = nullptr;
+      cudaFree(pamo.intersected_triangle_idx); pamo.intersected_triangle_idx = nullptr;
+      cudaFree(pamo.n_intersect); pamo.n_intersect = nullptr;
+    }
+
 public:
     ~CUDSP_Free()
     {
-      cudaDeviceSynchronize();
-      cudaFree(pamo.temp_storage);
-      cudaFree(pamo.first_near_tris);
-      cudaFree(pamo.near_tris);
-      cudaFree(pamo.near_offset);
-      cudaFree(pamo.first_edge);
-      cudaFree(pamo.edges);
-      cudaFree(pamo.vert_Q);
-      cudaFree(pamo.edge_cost);
-      cudaFree(pamo.tri_min_cost);
-      cudaFree(pamo.points);
-      cudaFree(pamo.triangles);
-      cudaFree(pamo.n_collapsed);
-      cudaFree(pamo.original_points);
-      cudaFree(pamo.original_tris);
-      cudaFree(pamo.original_edge_cost);
-      cudaFree(pamo.collapsed_edge_idx);
-      cudaFree(pamo.n_edges_undo);
-      cudaFree(pamo.edges_undo);
-      cudaFree(pamo.vertices_undo_list);
-      cudaFree(pamo.tmp_vertices_undo_list);
-      cudaFree(pamo.vertices_invalid_list);
-      cudaFree(pamo.vertices_invalid_table);
-      cudaFree(pamo.query_triangle_list);
-      cudaFree(pamo.intersected_triangle_idx);
-      cudaFree(pamo.n_intersect);
+      release();
     }
 
     //std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> forward(torch::Tensor points, torch::Tensor triangles, int iter, float scale, float epsilon, float threshold)
@@ -120,21 +129,28 @@ namespace cusimp
   {
     CUSimp sp;
 
+    void release()
+    {
+      cudaDeviceSynchronize();
+      cudaFree(sp.temp_storage); sp.temp_storage = nullptr;
+      cudaFree(sp.first_near_tris); sp.first_near_tris = nullptr;
+      cudaFree(sp.near_tris); sp.near_tris = nullptr;
+      cudaFree(sp.near_offset); sp.near_offset = nullptr;
+      cudaFree(sp.first_edge); sp.first_edge = nullptr;
+      cudaFree(sp.edges); sp.edges = nullptr;
+      cudaFree(sp.vert_Q); sp.vert_Q = nullptr;
+      cudaFree(sp.edge_cost); sp.edge_cost = nullptr;
+      cudaFree(sp.tri_min_cost); sp.tri_min_cost = nullptr;
+      cudaFree(sp.points); sp.points = nullptr;
+      cudaFree(sp.pts_occ); sp.pts_occ = nullptr;
+      cudaFree(sp.pts_map); sp.pts_map = nullptr;
+      cudaFree(sp.triangles); sp.triangles = nullptr;
+    }
+
 public:
     ~CUDSP()
     {
-      cudaDeviceSynchronize();
-      cudaFree(sp.temp_storage);
-      cudaFree(sp.first_near_tris);
-      cudaFree(sp.near_tris);
-      cudaFree(sp.near_offset);
-      cudaFree(sp.first_edge);
-      cudaFree(sp.edges);
-      cudaFree(sp.vert_Q);
-      cudaFree(sp.edge_cost);
-      cudaFree(sp.tri_min_cost);
-      cudaFree(sp.points);
-      cudaFree(sp.triangles);
+      release();
     }
 
     std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> forward(torch::Tensor points, torch::Tensor triangles, float scale, float threshold, bool init)


### PR DESCRIPTION
# Fix stage-2 CUDA leaks and multi-run collapse stall

## Summary

Stage-2 simplification (`CUSimp_Free::forward`) mis-owned device buffers across repeated calls, and recycled `cudaMalloc` memory left dirty state that could stop edge collapse after a few in-process runs (output stuck near remesh face count).

Two related fixes on this branch:

1. **Buffer leaks / ownership** — free-before-realloc and destructor completeness.
2. **Multi-run collapse stall** — zero/default dirty GPU buffers and correct DeviceToDevice copies from torch CUDA tensors.

## Root causes

### Leaks

`forward()` reallocated several member buffers without freeing the previous allocation. The main leak was `collapsed_edge_idx` (~O(n_edges) per call). `intersected_triangle_idx` also leaked on triangle-capacity growth. Pybind destructors never freed `pts_occ` / `pts_map`.

### Collapse stall

`cudaMalloc` does not zero memory. Across multi-run / multi-iteration use:

- `vertices_invalid_table` could retain random bits; when both endpoints looked invalid, costs became max and collapses stalled. The old clear only ran when `!is_stuck && n_verts_undo != 0`, and it ran *before* `ensure_pts_storage_size`, so a freshly malloc'd table was never cleared.
- `compute_edge_cost_kernel` early-returns without writing `edge_cost[edge_index]` (`is_stuck`, `dup_num != 2`). Uninitialized / recycled costs were then read by propagate/collapse.
- Points/triangles from torch CUDA tensors were copied with `cudaMemcpyHostToDevice`, which treats device pointers as host memory.

## Changes

### Leaks / ownership (`cusimp_free.cu`, `pybind.cpp`)

- Free before realloc each `forward()`:
  - `n_collapsed`, `collapsed_edge_idx`, `n_edges_undo`, `edges_undo`, `n_intersect`
- Free `intersected_triangle_idx` before triangle-capacity growth.
- Null pointers after `cudaFree`.
- Free `pts_occ` and `pts_map` in both pybind wrapper destructors; centralize `release()`.
- Guard zero-sized collapse/undo allocations and zero-block kernel launches (`n_edges == 0`, `h_n_collapsed == 0`).

### Dirty-buffer stall (`cusimp_free.cu`)

- Zero `vertices_invalid_table` after `ensure_pts` when `!is_stuck` (every non-stuck forward).
- When stuck, keep accumulated invalid bits and only OR in new undo verts.
- `cudaMemset(edge_cost, 0xFF, …)` before the cost kernel so unwritten edges stay blocked (max cost).
- Copy points/triangles with `cudaMemcpyDeviceToDevice` (torch CUDA tensors).

## Files

- `simp_cuda/src/cusimp_free.cu`
- `simp_cuda/src/pybind.cpp`

## Commits

1. `612b6dc` — Fix stage-2 buffer leaks: free-before-realloc and destructor ownership  
2. `2d2b038` — Fix stage-2 multi-run collapse stall from dirty GPU buffers  

## Tested

- Repeat stage-2 forwards in-process (same `CUDSP_Free` instance / multi-trial runs) on torch 2.8.1+cu128, warp-lang 1.14.
- Confirm collapses continue past the first few trials and final face count is not stuck near remesh output.
